### PR TITLE
Swap the order of function name and file line

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ pub extern "C" fn pyspy_snapshot(pid: Pid, ptr: *mut u8, len: i32, err_ptr: *mut
                             for frame in &thread.frames {
                                 let filename = match &frame.short_filename { Some(f) => &f, None => &frame.filename };
                                 if frame.line != 0 {
-                                    string_list.insert(0, format!("{}:{} - {}", filename, frame.line, frame.name));
+                                    string_list.insert(0, format!("{} - {}:{}", filename, frame.name, frame.line));
                                 } else {
                                     string_list.insert(0, format!("{} - {}", filename, frame.name));
                                 }


### PR DESCRIPTION
Function is usually more important than the line, so it would make sense to swap them.